### PR TITLE
Refactoring for 2.0

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,28 @@
+#### Upgrading from `1.x` to `2.0`
+
+The constructor signature of `SentryClient` has changed.
+
+If you had code like the following:
+
+```php
+$client = new SentryClient("https://0123456789abcdef0123456789abcdef@sentry.io/1234567");
+```
+
+You will need to upgrade to the new constructor signature as follows:
+
+```php
+$client = new SentryClient(
+    new DirectEventCapture(
+        new DSN("https://0123456789abcdef0123456789abcdef@sentry.io/1234567")
+    )
+);
+```
+
+The second constructor argument to the `SentryClient` constructor (`$extensions`) is
+the same as before.
+
+If you were using the public `SentryClient::$proxy` setting previously available, you
+can now provide this as a second argument to the `DirectEventCapture` constructor.
+
+Note the introduction of the `DSN` model, which may come in handy if you wish to build
+a custom `EventCapture` implementation for some reason.

--- a/composer.lock
+++ b/composer.lock
@@ -58,16 +58,16 @@
         },
         {
             "name": "psr/log",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
                 "shasum": ""
             },
             "require": {
@@ -101,7 +101,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "time": "2018-11-20T15:27:04+00:00"
         }
     ],
     "packages-dev": [
@@ -150,16 +150,16 @@
         },
         {
             "name": "nyholm/psr7",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Nyholm/psr7.git",
-                "reference": "02a20d5e9241daefd68935f7a43d9a7a8b4b6277"
+                "reference": "701fe7ea8c12c07b985b156d589134d328160cf7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Nyholm/psr7/zipball/02a20d5e9241daefd68935f7a43d9a7a8b4b6277",
-                "reference": "02a20d5e9241daefd68935f7a43d9a7a8b4b6277",
+                "url": "https://api.github.com/repos/Nyholm/psr7/zipball/701fe7ea8c12c07b985b156d589134d328160cf7",
+                "reference": "701fe7ea8c12c07b985b156d589134d328160cf7",
                 "shasum": ""
             },
             "require": {
@@ -175,7 +175,7 @@
             "require-dev": {
                 "http-interop/http-factory-tests": "dev-master",
                 "php-http/psr7-integration-tests": "dev-master",
-                "phpunit/phpunit": "^7.0"
+                "phpunit/phpunit": "^7.5"
             },
             "type": "library",
             "extra": {
@@ -208,7 +208,7 @@
                 "psr-17",
                 "psr-7"
             ],
-            "time": "2018-09-02T11:50:33+00:00"
+            "time": "2019-02-16T17:20:43+00:00"
         },
         {
             "name": "php-http/message-factory",

--- a/src/Extensions/BreadcrumbLogger.php
+++ b/src/Extensions/BreadcrumbLogger.php
@@ -84,8 +84,6 @@ class BreadcrumbLogger extends AbstractLogger implements SentryClientExtension
             $event->breadcrumbs,
             $this->breadcrumbs
         );
-
-        $this->clear();
     }
 
     /**

--- a/src/Model/BufferedEventCapture.php
+++ b/src/Model/BufferedEventCapture.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Kodus\Sentry\Model;
+
+/**
+ * This class implements buffered capture of {@see Event} instances to the
+ * Sentry back-end via an HTTP request.
+ *
+ * Buffered events must be explicitly flushed at the end of the request -
+ * for example, under FCGI, you could use `register_shutdown_function` and
+ * `fastcgi_finish_request` to first flush the response, and then flush any
+ * buffered events to Sentry, without blocking the user.
+ */
+class BufferedEventCapture implements EventCapture
+{
+    /**
+     * @var Event[]
+     */
+    private $events = [];
+
+    /**
+     * @var EventCapture|null
+     */
+    private $destination;
+
+    /**
+     * @param EventCapture $destination the destination `EventCapture` implementation to `flush()` to
+     */
+    public function __construct(EventCapture $destination)
+    {
+        $this->destination = $destination;
+    }
+
+    public function captureEvent(Event $event): void
+    {
+        $this->events[] = $event;
+    }
+
+    /**
+     * Flush all captured Events to the destination `EventCapture` implementation.
+     */
+    public function flush(): void
+    {
+        foreach ($this->events as $event) {
+            $this->destination->captureEvent($event);
+        }
+
+        $this->events = [];
+    }
+}

--- a/src/Model/DSN.php
+++ b/src/Model/DSN.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Kodus\Sentry\Model;
+
+use Kodus\Sentry\SentryClient;
+
+/**
+ * This model represents a Sentry DSN string
+ */
+class DSN
+{
+    /**
+     * @var string Sentry authorization header-name
+     *
+     * @see getAuthHeader()
+     */
+    const AUTH_HEADER_NAME = "X-Sentry-Auth";
+
+    /**
+     * @var string Sentry API endpoint
+     */
+    private $url;
+
+    /**
+     * @var string X-Sentry authentication header template
+     */
+    private $auth_header;
+
+    /**
+     * @var string
+     */
+    private $dsn;
+
+    /**
+     * @param string $dsn Sentry DSN string
+     */
+    public function __construct(string $dsn)
+    {
+        $this->dsn = $dsn;
+
+        $url = parse_url($dsn);
+
+        $auth_header = implode(
+            ", ",
+            [
+                "Sentry sentry_version=7",
+                "sentry_timestamp=%s",
+                "sentry_key={$url['user']}",
+                "sentry_client=kodus-sentry/" . SentryClient::VERSION,
+            ]
+        );
+
+        $this->auth_header = $auth_header;
+
+        $this->url = "{$url['scheme']}://{$url['host']}/api{$url['path']}/store/";
+    }
+
+    /**
+     * @return string
+     */
+    public function getURL(): string
+    {
+        return $this->url;
+    }
+
+    /**
+     * @return string authorization header-value
+     *
+     * @see DSN::AUTH_HEADER_NAME
+     */
+    public function getAuthHeader(): string
+    {
+        return sprintf($this->auth_header, $this->getTime());
+    }
+
+    /**
+     * @return string
+     */
+    public function getDSN(): string
+    {
+        return $this->dsn;
+    }
+
+    /**
+     * @internal
+     *
+     * @return float
+     */
+    protected function getTime(): float
+    {
+        return microtime(true);
+    }
+}

--- a/src/Model/DirectEventCapture.php
+++ b/src/Model/DirectEventCapture.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Kodus\Sentry\Model;
+
+use function json_decode;
+use function json_encode;
+use RuntimeException;
+
+/**
+ * This class implements capture of {@see Event} instances directly to the
+ * Sentry back-end via an HTTP request.
+ */
+class DirectEventCapture implements EventCapture
+{
+    /**
+     * @var string|null
+     */
+    private $proxy;
+
+    /**
+     * @var DSN
+     */
+    private $dsn;
+
+    /**
+     * @param DSN         $dsn
+     * @param string|null $proxy optional proxy server for outgoing HTTP requests (e.g. "tcp://proxy.example.com:5100")
+     */
+    public function __construct(DSN $dsn, ?string $proxy = null)
+    {
+        $this->dsn = $dsn;
+        $this->proxy = $proxy;
+    }
+
+    public function captureEvent(Event $event): void
+    {
+        $body = json_encode($event, \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES);
+
+        $headers = [
+            "Accept: application/json",
+            "Content-Type: application/json",
+            DSN::AUTH_HEADER_NAME . ": " . $this->dsn->getAuthHeader(),
+        ];
+
+        try {
+            $response = $this->fetch("POST", $this->dsn->getURL(), $body, $headers);
+        } catch (RuntimeException $error) {
+            error_log("SentryClient: unable to access Sentry service [{$error->getMessage()}]");
+
+            return; // NOTE: fail silently
+        }
+
+        $data = json_decode($response, true);
+
+        $event->event_id = $data["id"];
+    }
+
+    /**
+     * Perform an HTTP request and return the response body.
+     *
+     * The request must return a 200 status-code.
+     *
+     * @param string $method HTTP method ("GET", "POST", etc.)
+     * @param string $url
+     * @param string $body
+     * @param array  $headers
+     *
+     * @return string response body
+     *
+     * @throws RuntimeException if unable to open the resource
+     * @throws RuntimeException for unexpected (non-200) response code
+     */
+    protected function fetch(string $method, string $url, string $body, array $headers = []): string
+    {
+        $context = stream_context_create([
+            "http" => [
+                // http://docs.php.net/manual/en/context.http.php
+                "method"        => $method,
+                "header"        => implode("\r\n", $headers),
+                "content"       => $body,
+                "ignore_errors" => true,
+                "proxy"         => $this->proxy,
+            ],
+        ]);
+
+        $stream = @fopen($url, "r", false, $context);
+
+        if ($stream === false) {
+            throw new RuntimeException("unable to open resource: {$method} {$url}");
+        }
+
+        $response = stream_get_contents($stream);
+
+        $headers = stream_get_meta_data($stream)['wrapper_data'];
+
+        $status_line = $headers[0];
+
+        fclose($stream);
+
+        preg_match('{HTTP\/\S*\s(\d{3})}', $status_line, $match);
+
+        $status = $match[1];
+
+        if ($status !== "200") {
+            throw new RuntimeException("unexpected response status: {$status_line} ({$method} {$url})");
+        }
+
+        return $response;
+    }
+}

--- a/src/Model/EventCapture.php
+++ b/src/Model/EventCapture.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Kodus\Sentry\Model;
+
+/**
+ * This interface abstracts the capture of {@see Event} objects to Sentry.
+ */
+interface EventCapture
+{
+    /**
+     * Capture a given {@see Event} to Sentry.
+     *
+     * @param Event $event
+     */
+    public function captureEvent(Event $event): void;
+}


### PR DESCRIPTION
Some refactoring, introducing some new abstractions to enable buffering Sentry events and flushing them *after* sending the response. (avoiding delays to post to Sentry, to improve the user experience when we log warnings/notices during a request.)
