### PR TITLE
Add a new "callable" extension class

### DIFF
--- a/src/Extensions/CallableExtension.php
+++ b/src/Extensions/CallableExtension.php
@@ -10,19 +10,19 @@ use Psr\Http\Message\ServerRequestInterface;
 class CallableExtension implements SentryClientExtension
 {
 	/**
-    * @var Closure(Event, ServerRequestInterface|null):void
-    */
+	 * @var Closure(Event, Throwable, ServerRequestInterface|null):void
+	 */
 	private $callable;
 
 	/**
-    * @param Closure(Event, ServerRequestInterface|null):void $callable
-    */
+	 * @param Closure(Event, Throwable, ServerRequestInterface|null):void $callable
+	 */
 	public function __construct(callable $callable) {
 		$this->callable = $callable;
 	}
 
 	public function apply(Event $event, Throwable $exception, ?ServerRequestInterface $request): void {
 		$callable = $this->callable;
-		$callable($event, $request);
+		$callable($event, $exception, $request);
 	}
 }

--- a/src/Extensions/CallableExtension.php
+++ b/src/Extensions/CallableExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Kodus\Sentry\Extensions;
+
+use Throwable;
+use Kodus\Sentry\Model\Event;
+use Kodus\Sentry\SentryClientExtension;
+use Psr\Http\Message\ServerRequestInterface;
+
+class CallableExtension implements SentryClientExtension
+{
+	/**
+    * @var Closure(Event, ServerRequestInterface|null):void
+    */
+	private $callable;
+
+	/**
+    * @param Closure(Event, ServerRequestInterface|null):void $callable
+    */
+	public function __construct(callable $callable) {
+		$this->callable = $callable;
+	}
+
+	public function apply(Event $event, Throwable $exception, ?ServerRequestInterface $request): void {
+		$callable = $this->callable;
+		$callable($event, $request);
+	}
+}


### PR DESCRIPTION
This extension allows a custom callable, making it simpler for clients to do ad-hoc extensions in local scope without having to make specific extension classes for each use case.

For example a client could wrap their own container for the Sentry class, and set context on this as a user progresses through a flow. At the time an exception is handled they want current context passed in. They could set this up in advance using the callable extension like so:

```
$fn_release = static function (Event $event): void{
  $event->release = $event->release ?: self::getRelease();
};

return new CallableExtension($fn_release);
```

So the initial setup saves this extension, but if the context (in this case static context, for cross-cutting concerns) has new data by the time the stack is processed, the callable extension pulls that in.