### PR TITLE
Add a new "callable" extension class 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea
 /tests/_output
 /composer.lock
+composer.phar

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-`kodus/sentry`
+`sturents/sentry-light`
 ==============
 
-Lightweight [Sentry](https://sentry.io/welcome/) client with no dependencies.
+Lightweight [Sentry](https://sentry.io/welcome/) client with no dependencies. Forked from `kodus/sentry` as that package is no longer
+maintained and is causing breaks in newer PHP versions.
 
 [![PHP Version](https://img.shields.io/badge/php-7.1%2B-blue.svg)](https://packagist.org/packages/kodus/sentry)
 ![Build Status](https://github.com/kodus/sentry/actions/workflows/test.yml/badge.svg)

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     "require-dev": {
         "nyholm/psr7": "^1.0",
         "codeception/codeception": "^5.0",
-        "codeception/module-asserts": "*"
+        "codeception/module-asserts": "*",
+        "vimeo/psalm": "^5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "kodus/sentry",
-    "description": "Lightweight alternative to the official Sentry client for PHP",
+    "name": "sturents/sentry-light",
+    "description": "Lightweight alternative to the official Sentry client for PHP. Forked from kodus/sentry",
     "type": "library",
     "license": "MIT",
     "authors": [
@@ -13,12 +13,12 @@
         "php": ">=8.0",
         "ext-json": "*",
         "psr/http-message": "^1.0",
-        "psr/log": "^1.0",
-        "codeception/codeception": "^5.0",
-        "codeception/module-asserts": "*"
+        "psr/log": "^1.0"
     },
     "require-dev": {
-        "nyholm/psr7": "^1.0"
+        "nyholm/psr7": "^1.0",
+        "codeception/codeception": "^5.0",
+        "codeception/module-asserts": "*"
     },
     "autoload": {
         "psr-4": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="4"
+    resolveFromConfigFile="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="true"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+    <issueHandlers>
+        <!-- This set can be removed by adding psalm-api tags -->
+        <PossiblyUnusedMethod errorLevel="suppress"/>
+        <PossiblyUnusedProperty errorLevel="suppress"/>
+        <UnusedClass errorLevel="suppress"/>
+    </issueHandlers>
+</psalm>

--- a/src/Extensions/CallableExtension.php
+++ b/src/Extensions/CallableExtension.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Kodus\Sentry\Extensions;
+
+use Throwable;
+use Kodus\Sentry\Model\Event;
+use Kodus\Sentry\SentryClientExtension;
+use Psr\Http\Message\ServerRequestInterface;
+
+class CallableExtension implements SentryClientExtension
+{
+	/**
+	 * @var Closure(Event, Throwable, ServerRequestInterface|null):void
+	 */
+	private $callable;
+
+	/**
+	 * @param Closure(Event, Throwable, ServerRequestInterface|null):void $callable
+	 */
+	public function __construct(callable $callable) {
+		$this->callable = $callable;
+	}
+
+	public function apply(Event $event, Throwable $exception, ?ServerRequestInterface $request): void {
+		$callable = $this->callable;
+		$callable($event, $exception, $request);
+	}
+}

--- a/src/Extensions/ExceptionReporter.php
+++ b/src/Extensions/ExceptionReporter.php
@@ -350,7 +350,7 @@ class ExceptionReporter implements SentryClientExtension
      *
      * @param mixed[] $values raw PHP values
      *
-     * @return string[] formatted values
+     * @return list<string> formatted values
      */
     protected function formatValues(array $values): array
     {

--- a/src/Model/Breadcrumb.php
+++ b/src/Model/Breadcrumb.php
@@ -44,6 +44,10 @@ class Breadcrumb implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
-        return array_filter(get_object_vars($this));
+		// Avoids a psalm error for unused property on "data"
+		$out = array_merge(get_object_vars($this), [
+			'data' => $this->data,
+		]);
+        return array_filter($out);
     }
 }

--- a/src/Model/Request.php
+++ b/src/Model/Request.php
@@ -25,9 +25,9 @@ class Request implements JsonSerializable
     public $query_string;
 
     /**
-     * @var string|null cookie values (unparsed, as a string)
+     * @var array cookie values (unparsed, as a string)
      */
-    public $cookies;
+    public $cookies = [];
 
     /**
      * @var string[] map where header-name => header-value


### PR DESCRIPTION
This extension allows a custom callable, making it simpler for clients to do ad-hoc extensions in local scope without having to make specific extension classes for each use case.

For example a client could wrap their own container for the Sentry class, and set context on this as a user progresses through a flow. At the time an exception is handled they want current context passed in. They could set this up in advance using the callable extension like so:

```
$fn_release = static function (Event $event): void{
  $event->release = $event->release ?: self::getRelease();
};

return new CallableExtension($fn_release);
```

So the initial setup saves this extension, but if the context (in this case static context, for cross-cutting concerns) has new data by the time the stack is processed, the callable extension pulls that in.

(originally made here: https://github.com/kodus/sentry/pull/9)